### PR TITLE
Correct predictors to deal with situations when zero is a bad guess

### DIFF
--- a/pyzag/nonlinear.py
+++ b/pyzag/nonlinear.py
@@ -151,8 +151,8 @@ class PreviousStepsPredictor:
         """
         if k - kinc < 0:
             res = torch.zeros_like(results[k : k + kinc])
-            res[kinc-k:] = results[0:k]
-            res[:kinc-k] = results[0]
+            res[kinc - k :] = results[0:k]
+            res[: kinc - k] = results[0]
             return res
 
         return results[(k - kinc) : k]
@@ -209,8 +209,8 @@ class ExtrapolatingPredictor:
         """
         if k - kinc < 0:
             res = torch.zeros_like(results[k : k + kinc])
-            res[kinc-k:] = results[0:k]
-            res[:kinc-k] = results[0]
+            res[kinc - k :] = results[0:k]
+            res[: kinc - k] = results[0]
             return res
         if k - 2 * kinc - 1 < 0:
             return results[(k - kinc) : k]

--- a/pyzag/nonlinear.py
+++ b/pyzag/nonlinear.py
@@ -149,8 +149,12 @@ class PreviousStepsPredictor:
             k (int): start of current chunk
             kinc (int): next number of steps to predict
         """
-        if k - kinc - 1 < 0:
-            return torch.zeros_like(results[k : k + kinc])
+        if k - kinc < 0:
+            res = torch.zeros_like(results[k : k + kinc])
+            res[kinc-k:] = results[0:k]
+            res[:kinc-k] = results[0]
+            return res
+
         return results[(k - kinc) : k]
 
 
@@ -203,8 +207,11 @@ class ExtrapolatingPredictor:
             k (int): start of current chunk
             kinc (int): next number of steps to predict
         """
-        if k - kinc - 1 < 0:
-            return torch.zeros_like(results[k : k + kinc])
+        if k - kinc < 0:
+            res = torch.zeros_like(results[k : k + kinc])
+            res[kinc-k:] = results[0:k]
+            res[:kinc-k] = results[0]
+            return res
         if k - 2 * kinc - 1 < 0:
             return results[(k - kinc) : k]
 

--- a/test/test_predictors.py
+++ b/test/test_predictors.py
@@ -96,8 +96,8 @@ class TestPreviousStepsPredictor(BasePredictor):
         dk = 10
 
         pred = torch.zeros((dk, self.nbatch, self.nstate))
-        pred[dk-k:] = self.data[:k]
-        pred[:dk-k] = self.data[0]
+        pred[dk - k :] = self.data[:k]
+        pred[: dk - k] = self.data[0]
 
         self.assertTrue(
             torch.allclose(

--- a/test/test_predictors.py
+++ b/test/test_predictors.py
@@ -94,9 +94,14 @@ class TestPreviousStepsPredictor(BasePredictor):
     def test_prediction_not_enough_steps(self):
         k = 5
         dk = 10
+
+        pred = torch.zeros((dk, self.nbatch, self.nstate))
+        pred[dk-k:] = self.data[:k]
+        pred[:dk-k] = self.data[0]
+
         self.assertTrue(
             torch.allclose(
                 self.predictor.predict(self.data, k, dk),
-                torch.zeros((dk, self.nbatch, self.nstate)),
+                pred,
             )
         )


### PR DESCRIPTION
Correct the previous step and extrapolating predictors to use as much of the previous history as possible for a guess if the incremental would take you beyond the previous history.  Even if you do exceed the previous history use the initial step, rather than zero, as a guess.