### PR TITLE
Bump version 1.1.1 -> 1.1.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@
 project = "pyzag"
 copyright = "2025, Argonne National Laboratory"
 author = "Argonne National Laboratory"
-release = "1.1.1"
+release = "1.1.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyzag"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
   { name="Mark Messner", email="messner@anl.gov" },
 ]


### PR DESCRIPTION
## What

Version bump only: `1.1.1` → `1.1.2` (`pyproject.toml` + `docs/conf.py`). No code changes.

## Why

`requirements.txt` already declares `numpy>=2` (merged in #25 "numpy ver >= 2"), but the released `1.1.1` still effectively pins `numpy<2` for anything that depends on it. Cutting `1.1.2` publishes a pyzag that no longer constrains numpy below 2.

Downstream: this unblocks `neml2` from depending on a pyzag that drags `numpy<2` into every `pip install neml2` — which currently downgrades numpy on Google Colab and conflicts with Colab's `numpy>=2` packages (opencv, jax, …). Once `1.1.2` is on PyPI, neml2 will bump its pin to `pyzag==1.1.2`.

## Release

After merge: create a GitHub Release/tag for `v1.1.2` to trigger the `python.yml` PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)