### PR TITLE
Disable AOTAutograd donated buffers for the adjoint (1.1.3)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@
 project = "pyzag"
 copyright = "2025, Argonne National Laboratory"
 author = "Argonne National Laboratory"
-release = "1.1.2"
+release = "1.1.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyzag"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
   { name="Mark Messner", email="messner@anl.gov" },
 ]

--- a/pyzag/nonlinear.py
+++ b/pyzag/nonlinear.py
@@ -24,9 +24,65 @@
 
 """Basic functionality for solving recursive nonlinear equations and calculating senstivities using the adjoint method"""
 
+import warnings
+
 import torch
 
 from pyzag import chunktime
+
+
+def _disable_donated_buffers() -> None:
+    """Lower torch's AOTAutograd ``donated_buffer`` default so pyzag's adjoint works
+    with ``torch.compile``.
+
+    pyzag's adjoint reuses the autograd graph across the reverse sweep via
+    ``torch.autograd.grad(..., retain_graph=True)`` (see
+    :meth:`RecursiveNonlinearEquationSolver.accumulate`). On torch>=2.12 AOTAutograd
+    collects "donated buffers" for a ``torch.compile``'d graph, and a backward compiled
+    with non-empty donated buffers *requires* ``retain_graph=False``. So a compiled model
+    differentiated through pyzag's adjoint raises
+    ``RuntimeError: ... compiled with non-empty donated buffers ...``.
+
+    ``donated_buffer`` is a ``ContextVar``-backed torch config. AOTAutograd compiles and
+    runs the backward under its own contextvars contexts, where a normal
+    ``torch._functorch.config.donated_buffer = False`` (or ``config.patch``) override is
+    not visible -- those contexts read the config *default*. So the only setting that
+    actually reaches them is the default, which we lower here, process-wide.
+
+    This is deliberately blunt: it lowers a global torch default the first time a
+    :class:`RecursiveNonlinearEquationSolver` is constructed. It is scoped to actual
+    pyzag use -- merely importing pyzag (or neml2) does not touch the default, so code
+    that never runs the adjoint is unaffected. A ``UserWarning`` is emitted once, when it
+    takes effect. To keep donated buffers enabled, restore the default::
+
+        import torch._functorch.config as c
+        c._config["donated_buffer"].default = True
+
+    The consequence of restoring it: any ``torch.compile``'d model differentiated through
+    pyzag's adjoint will raise the donated-buffer error again. (Donation saves a little
+    backward memory, but is fundamentally incompatible with ``retain_graph=True``.)
+    """
+    try:
+        import torch._functorch.config as functorch_config
+
+        # pylint: disable=protected-access
+        entry = functorch_config._config["donated_buffer"]
+    except (ImportError, KeyError, AttributeError):
+        return  # older/other torch without the flag -- nothing to disable
+
+    if getattr(entry, "default", False):
+        entry.default = False
+        warnings.warn(
+            "pyzag lowered torch._functorch.config.donated_buffer's default to False "
+            "process-wide. AOTAutograd 'donated buffers' (torch>=2.12) are incompatible "
+            "with pyzag's retain_graph=True adjoint over torch.compile'd models, which "
+            "otherwise raises 'compiled with non-empty donated buffers'. To keep donated "
+            "buffers enabled, restore "
+            "torch._functorch.config._config['donated_buffer'].default = True -- "
+            "compiled models differentiated through the adjoint will then error.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 class NonlinearRecursiveFunction(torch.nn.Module):
@@ -350,6 +406,11 @@ class RecursiveNonlinearEquationSolver(torch.nn.Module):
         convert_nan_gradients=True,
     ):
         super().__init__()
+        # Lower torch's AOTAutograd donated-buffer default so the adjoint (which uses
+        # retain_graph=True) works with torch.compile'd models. Scoped here to actual
+        # solver use, and runs before any solve compiles a backward. Process-global and
+        # emits a one-time warning; see _disable_donated_buffers.
+        _disable_donated_buffers()
         # Store basic information
         self.func = func
 


### PR DESCRIPTION
## Symptom

A `torch.compile`'d model differentiated through pyzag's adjoint (on torch ≥ 2.12) raises:

```
RuntimeError: This backward function was compiled with non-empty donated buffers
which requires create_graph=False and retain_graph=False ...
```

## Root cause

- pyzag's adjoint reuses the autograd graph across the reverse sweep via `torch.autograd.grad(..., retain_graph=True)` (`RecursiveNonlinearEquationSolver.accumulate`). It cannot avoid `retain_graph=True`.
- torch ≥ 2.12 AOTAutograd collects **donated buffers** for a `torch.compile`'d graph; a backward compiled with non-empty donated buffers **requires `retain_graph=False`**. The two are fundamentally incompatible.
- `torch._functorch.config.donated_buffer` is a **`ContextVar`-backed** config. AOTAutograd compiles and runs the backward under its own contextvars contexts, where a normal `config.donated_buffer = False` (or `config.patch(...)`) override is **not visible** — those contexts read the config **default**. (Verified with an in-torch probe: at the compile gate, `user_override=<UNSET>`, so it reads `default`.) So the usual override never reaches the code that decides donation.

## Fix

Lower the config **default** (the only setting that reaches AOTAutograd's contexts), scoped to `RecursiveNonlinearEquationSolver.__init__` — it runs before any solve compiles a backward, and importantly **merely importing pyzag (or neml2) does not touch the global**, so non-adjoint code and unrelated `torch.compile` users are unaffected. It is process-global and emits a **one-time `UserWarning`** explaining the change and how to revert it (`config._config['donated_buffer'].default = True`) with the consequence spelled out. No-op on torch builds without the flag.

## Verification

- pyzag test suite: **28 passed, 649 subtests** (1 warning — the intentional one).
- Scoping confirmed: `import neml2` leaves the default `True`; constructing a solver sets it `False` + warns once.
- End-to-end: neml2's two pyzag calibration notebooks (deterministic + statistical), which `neml2.compile` the residual and run the adjoint, fail without this and pass with it on torch 2.12.1 (and 2.12.0).
- black + copyright clean.

After merge: tag/release **v1.1.3** to publish to PyPI; neml2 will then pin `pyzag==1.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)