### PR TITLE
Publish a py3-none-any wheel (bump 1.1.4)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,22 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sdist:
-    name: Build source distribution
+  dist:
+    name: Build distributions (sdist + wheel)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build SDist
-        run: pipx run build --sdist
-      - name: Upload SDist
+      - name: Build sdist + wheel
+        # `build` with no --sdist produces BOTH the sdist and a py3-none-any
+        # wheel. pyzag is pure Python, so the wheel is universal: pip installs it
+        # on every platform with no build step. That matters for consumers that
+        # build under --no-build-isolation (e.g. neml2's Windows/MSVC build), where
+        # an sdist-only release forces a source build that fails without `wheel`.
+        # Building both on every push/PR also keeps the wheel build under CI.
+        run: pipx run build
+      - name: Upload distributions
         uses: actions/upload-artifact@v4
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          name: package-sdist
-          path: dist/*.tar.gz
+          name: package-dist
+          path: dist/*
 
   PyPI:
-    needs: sdist
+    needs: dist
     environment: pypi
     permissions:
       id-token: write
@@ -39,7 +45,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: package-sdist
+          pattern: package-dist
           path: dist
           merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyzag"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Mark Messner", email="messner@anl.gov" },
 ]


### PR DESCRIPTION
## Problem

The release workflow builds only an **sdist** (`build --sdist`), so every pyzag release on PyPI is source-only (1.1.3 has just `pyzag-1.1.3.tar.gz`). pip then has to *build* pyzag from source at install time, which fails under `--no-build-isolation` when `wheel` isn't in the environment:

```
error: invalid command 'bdist_wheel'
```

This is exactly what blocks neml2's Windows/MSVC build (`pip install . --no-build-isolation`), and it slows/roughens installs everywhere.

## Fix

pyzag is pure Python, so a `py3-none-any` wheel is universal — pip installs it on **every** platform with no build step.

- Build **both** sdist and wheel (`build` with no `--sdist`) and publish both on release.
- Building on every push/PR also keeps the wheel build exercised in CI.
- Bump `1.1.3 → 1.1.4` so the wheel ships as a new release.

Verified locally: `python -m build` produces `pyzag-1.1.4-py3-none-any.whl` + `pyzag-1.1.4.tar.gz`.

## After merge

Publish a **1.1.4** GitHub release (auto-triggers the PyPI publish via the existing trusted-publishing job). Then neml2's pin can move `pyzag==1.1.3 → 1.1.4` to pick up the wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)